### PR TITLE
Move dev dependency to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0 || ^8.0",
-        "phpcompatibility/phpcompatibility-wp": "^2.1"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.8",
-        "guzzlehttp/guzzle": "~5.0"
+        "guzzlehttp/guzzle": "~5.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1"
     },
     "suggest": {
         "paragonie/random_compat": "Provides a better CSPRNG option in PHP 5",


### PR DESCRIPTION
With it in `require`, any consuming package running `composer i --no-dev` will still get all of the PHPCS-related packages installed.